### PR TITLE
language 支持 function

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -18,7 +18,9 @@ export default class BraftFinder extends FinderController {
       ...props
     }
 
-    const language = componentProps.language ? (languages[componentProps.language] || languages['zh']) : languages['zh']
+    const language = (typeof componentProps.language === 'function'
+      ? componentProps.language(languages)
+      : languages[componentProps.language]) || languages['zh']
 
     return (
       <FinderView


### PR DESCRIPTION
`braft-editor` 有些地方也应改动，给定一个命名空间。如 `language['zh'].finder`