### PR TITLE
拖动文件经过drop区域，不再其中drop会导致组件一直处于dragging状态

### DIFF
--- a/src/view.jsx
+++ b/src/view.jsx
@@ -106,7 +106,6 @@ export default class BraftFinderView extends React.Component {
       <div className="braft-finder">
         <div
           onDragEnter={this.handleDragEnter}
-          onDragOver={this.handleDragEnter}
           onDragLeave={this.handleDragLeave}
           onDrop={this.handleDragDrop}
           className="bf-uploader"


### PR DESCRIPTION
拖动后不松开，导致整个状态不正确